### PR TITLE
Use manual agent in conversation HTTP endpoint

### DIFF
--- a/functions/http_conversation.py
+++ b/functions/http_conversation.py
@@ -1,27 +1,44 @@
+import json
 import logging
+
 import azure.functions as func
 from function_app import app
+
+from agents.manual_agent import create_manual_agent
+
+
+_agent = None
 
 
 @app.route(route="conversationRun", auth_level=func.AuthLevel.FUNCTION)
 def conversation_run(req: func.HttpRequest) -> func.HttpResponse:
+    """HTTP endpoint for running a manual agent conversation."""
+
     logging.info("HTTP conversationRun invoked")
 
-    name = req.params.get("name")
-    if not name:
-        try:
-            req_body = req.get_json()
-            name = req_body.get("name") if isinstance(req_body, dict) else None
-        except ValueError:
-            name = None
+    try:
+        body = req.get_json()
+    except ValueError:
+        return func.HttpResponse(status_code=400)
 
-    if name:
-        return func.HttpResponse(
-            f"Hello, {name}. This HTTP triggered function executed successfully.",
-            status_code=200,
-        )
+    if not isinstance(body, dict):
+        return func.HttpResponse(status_code=400)
+
+    machine_name = body.get("machine_name")
+    input_data = body.get("input")
+
+    if machine_name is None or input_data is None:
+        return func.HttpResponse(status_code=400)
+
+    global _agent
+    if _agent is None:
+        _agent = create_manual_agent()
+
+    result = _agent.invoke({"input": input_data, "machine_name": machine_name})
+    output = result.get("output") if isinstance(result, dict) else result
 
     return func.HttpResponse(
-        "This HTTP triggered function executed successfully. Pass a name in the query string or in the request body for a personalized response.",
+        json.dumps({"output": output}),
         status_code=200,
+        mimetype="application/json",
     )


### PR DESCRIPTION
## Summary
- invoke manual agent in HTTP `conversationRun` endpoint
- validate request payload and return agent output as JSON

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf265dc654832cbedb89d1abcc0ce0