### PR TITLE
Surface manual storage and Azure OpenAI settings

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -13,6 +13,10 @@ Parameters (main.bicep)
 - `cosmosDbName`: Cosmos DB database name
 - `cosmosContainerName`: Cosmos DB container name
 - `sqlAdminLogin` / `sqlAdminPassword`: SQL admin credentials
+- `manualsMdConnectionString`: Connection string for manuals markdown storage (blob container)
+- `azureOpenAiEndpoint`: Azure OpenAI endpoint URL
+- `azureOpenAiApiKey`: Azure OpenAI API key
+- `azureOpenAiDeployment`: Azure OpenAI deployment name
 
 Deploy
 1) Create resource group (if needed):
@@ -22,7 +26,13 @@ Deploy
    az deployment group create \
      -g rg-machine-bot \
      -f infra/main.bicep \
-     -p namePrefix=mbot location=westeurope cosmosDbName=mbotdb cosmosContainerName=mbotitems sqlAdminLogin=sqladmin sqlAdminPassword=YOUR_STRONG_PASSWORD
+     -p namePrefix=mbot location=westeurope cosmosDbName=mbotdb cosmosContainerName=mbotitems \
+        sqlAdminLogin=sqladmin sqlAdminPassword=YOUR_STRONG_PASSWORD \
+        manualsMdConnectionString=YOUR_STORAGE_CONNECTION \
+        azureOpenAiEndpoint=YOUR_OPENAI_ENDPOINT \
+        azureOpenAiApiKey=YOUR_OPENAI_KEY \
+        azureOpenAiDeployment=YOUR_OPENAI_DEPLOYMENT
 
-Outputs include connection values you can set as application settings locally (or wire via Key Vault).
+Outputs include connection values and URLs you can set as application settings locally (or wire via Key Vault). The `conversationRunUrl`
+output gives the HTTP endpoint for the sample function (requires a function key).
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -13,6 +13,20 @@ param sqlAdminPassword string
 @description('SQL admin login name')
 param sqlAdminLogin string
 
+@secure()
+@description('Connection string for manuals markdown storage')
+param manualsMdConnectionString string
+
+@description('Azure OpenAI endpoint URL')
+param azureOpenAiEndpoint string
+
+@secure()
+@description('Azure OpenAI API key')
+param azureOpenAiApiKey string
+
+@description('Azure OpenAI deployment name')
+param azureOpenAiDeployment string
+
 var storageAccountName = toLower('${namePrefix}stor${uniqueString(resourceGroup().id)}')
 var functionAppName = toLower('${namePrefix}-func-${uniqueString(resourceGroup().id)}')
 var appInsightsName = toLower('${namePrefix}-appi')
@@ -127,6 +141,22 @@ resource func 'Microsoft.Web/sites@2022-09-01' = {
           name: 'SqlConnectionString'
           value: sql.outputs.connectionString
         }
+        {
+          name: 'MANUALS_MD_CONNECTION_STRING'
+          value: manualsMdConnectionString
+        }
+        {
+          name: 'AZURE_OPENAI_ENDPOINT'
+          value: azureOpenAiEndpoint
+        }
+        {
+          name: 'AZURE_OPENAI_API_KEY'
+          value: azureOpenAiApiKey
+        }
+        {
+          name: 'AZURE_OPENAI_DEPLOYMENT'
+          value: azureOpenAiDeployment
+        }
       ]
     }
   }
@@ -139,4 +169,9 @@ output cosmosPrimaryKey string = cosmos.outputs.primaryKey
 output cosmosConnectionString string = cosmos.outputs.connectionString
 output sqlServerFqdn string = sql.outputs.fqdn
 output sqlConnectionString string = sql.outputs.connectionString
+output manualsMdConnectionString string = manualsMdConnectionString
+output azureOpenAiEndpoint string = azureOpenAiEndpoint
+output azureOpenAiApiKey string = azureOpenAiApiKey
+output azureOpenAiDeployment string = azureOpenAiDeployment
+output conversationRunUrl string = 'https://${functionAppName}.azurewebsites.net/api/conversationRun'
 


### PR DESCRIPTION
## Summary
- surface manuals markdown and Azure OpenAI configuration in infra template
- document new parameters and endpoint output

## Testing
- `bicep build infra/main.bicep` *(fails: command not found: bicep)*
- `az bicep version` *(fails: command not found: az)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'middleware')*

------
https://chatgpt.com/codex/tasks/task_e_68bf266bb32c832ca6c0a521ba61d7b4