### PR TITLE
Add agent and function tests with safe manual tooling

### DIFF
--- a/tests/test_dispatcher_agent.py
+++ b/tests/test_dispatcher_agent.py
@@ -1,0 +1,34 @@
+"""Basic tests for dispatcher and maintenance agents."""
+from __future__ import annotations
+
+import agents.vanilla_agent as vanilla_agent
+from agents.dispatcher_agent import DispatcherAgent
+from agents.maintenance_agent import MaintenanceAgent
+from langchain_core.messages import AIMessage
+
+
+class FakeListChatModel:
+    def __init__(self, responses):
+        self._responses = list(responses)
+
+    def bind_tools(self, tools):
+        return self
+
+    def invoke(self, messages):  # pragma: no cover
+        return self._responses.pop(0)
+
+
+def test_dispatcher_agent_basic_response(monkeypatch):
+    model = FakeListChatModel([AIMessage(content="dispatch ok")])
+    monkeypatch.setattr(vanilla_agent, "AzureChatOpenAI", lambda **_: model)
+    agent = DispatcherAgent()
+    result = agent.invoke({"input": "hello"})
+    assert result["messages"][-1].content == "dispatch ok"
+
+
+def test_maintenance_agent_basic_response(monkeypatch):
+    model = FakeListChatModel([AIMessage(content="maintenance ok")])
+    monkeypatch.setattr(vanilla_agent, "AzureChatOpenAI", lambda **_: model)
+    agent = MaintenanceAgent()
+    result = agent.invoke({"input": "check"})
+    assert result["messages"][-1].content == "maintenance ok"

--- a/tests/test_manual_agent.py
+++ b/tests/test_manual_agent.py
@@ -1,69 +1,80 @@
-#TODO: Rewerite these tests to use pytest well
+"""Tests for the Manuals agent."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import agents.vanilla_agent as vanilla_agent
+from agents.manual_agent import ManualAgent
+from langchain_core.messages import AIMessage
 
 
-# import pytest
+class FakeListChatModel:
+    """Simple fake chat model returning preset responses."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+
+    def bind_tools(self, tools):
+        return self
+
+    def invoke(self, messages):  # pragma: no cover - simple passthrough
+        return self._responses.pop(0)
 
 
-# manual_agent = pytest.importorskip("agents.manual_agent")
-# langchain = pytest.importorskip("langchain")
-# pytest.importorskip("langchain_openai")
-
-# from langchain_core.messages import AIMessage, ToolCall
-# from langchain_core.chat_models.fake import FakeListChatModel
-
-
-# def _build_fake_tool_call_model():
-#     responses = [
-#         AIMessage(
-#             content="",
-#             tool_calls=[
-#                 ToolCall(
-#                     name="manual_markdown_lookup",
-#                     args={
-#                         "machine_name": "machine001",
-#                         "user_message": "How do I use it?",
-#                     },
-#                     id="call_1",
-#                 )
-#             ],
-#         ),
-#         AIMessage(content="Manual consulted"),
-#     ]
-#     return FakeListChatModel(responses=responses)
+def _build_fake_tool_call_model():
+    responses = [
+        AIMessage(
+            content="",
+            additional_kwargs={
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "function": {
+                            "name": "manuals_tool",
+                            "arguments": "{\"machine_name\": \"machine001\"}",
+                        },
+                    }
+                ]
+            },
+        ),
+        AIMessage(content="Manual consulted"),
+    ]
+    return FakeListChatModel(responses)
 
 
-# def _build_fake_final_model():
-#     responses = [AIMessage(content="saw image")]
-#     return FakeListChatModel(responses=responses)
+def _build_fake_final_model():
+    responses = [AIMessage(content="saw image")]
+    return FakeListChatModel(responses)
 
 
-# @pytest.fixture
-# def manual_file(tmp_path):
-#     manuals = tmp_path / "manuals-md"
-#     manuals.mkdir()
-#     (manuals / "machine001.md").write_text("Step 1")
-#     return manuals
+@pytest.fixture
+def manuals_dir() -> Path:
+    return Path(__file__).parent / "data"
 
 
-# def test_agent_invokes_manual_tool(monkeypatch, manual_file):
-#     fake_model = _build_fake_tool_call_model()
-#     monkeypatch.setattr(
-#         manual_agent, "AzureChatOpenAI", lambda **_: fake_model
-#     )
-#     agent = manual_agent.create_manual_agent(fallback_path=str(manual_file))
-#     result = agent.invoke({"input": "How do I use it?", "machine_name": "machine001"})
-#     assert "Step 1" in result["output"]
+def test_agent_invokes_manual_tool(monkeypatch, manuals_dir: Path):
+    fake_model = _build_fake_tool_call_model()
+    monkeypatch.setattr(vanilla_agent, "AzureChatOpenAI", lambda **_: fake_model)
+    monkeypatch.setenv("MANUALS_MD_PATH", str(manuals_dir))
+    agent = ManualAgent()
+    result = agent.invoke(
+        {"input": "How do I use it?", "machine_name": "machine001"}
+    )
+    tool_messages = [m for m in result["messages"] if m.__class__.__name__ == "ToolMessage"]
+    assert any("Operator & Maintenance Manual" in m.content for m in tool_messages)
+    assert result["messages"][-1].content == "Manual consulted"
 
 
-# def test_agent_accepts_image_input(monkeypatch, manual_file):
-#     fake_model = _build_fake_final_model()
-#     monkeypatch.setattr(
-#         manual_agent, "AzureChatOpenAI", lambda **_: fake_model
-#     )
-#     agent = manual_agent.create_manual_agent(fallback_path=str(manual_file))
-#     img_input = [
-#         {"type": "text", "text": "What is shown?"},
-#         {"type": "image_url", "image_url": {"url": "http://example.com"}},
-#     ]
-#     result = agent.invoke({"input": img_input, "machine_name": "machine001"})
-#     assert result["output"] == "saw image"
+def test_agent_accepts_image_input(monkeypatch, manuals_dir: Path):
+    fake_model = _build_fake_final_model()
+    monkeypatch.setattr(vanilla_agent, "AzureChatOpenAI", lambda **_: fake_model)
+    monkeypatch.setenv("MANUALS_MD_PATH", str(manuals_dir))
+    agent = ManualAgent()
+    img_input = [
+        {"type": "text", "text": "What is shown?"},
+        {"type": "image_url", "image_url": {"url": "http://example.com"}},
+    ]
+    result = agent.invoke({"input": img_input, "machine_name": "machine001"})
+    assert result["messages"][-1].content == "saw image"


### PR DESCRIPTION
## Summary
- add tests for Manuals agent including tool use and image inputs
- cover dispatcher and maintenance agents with fake models
- test HTTP conversation function with dummy graph
- skip ManualsTool integration tests when Azure storage is unavailable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7d25fa860832c90637ab2849251ac