### PR TITLE
feat: add azure ai search integration tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,58 @@
+# AGENTS.md
+
+## Project summary
+Machine Bot is an Azure Functions (Python) application that orchestrates LangChain agents to answer questions about manufacturing machines.  The app exposes HTTP, timer, queue, and Cosmos DB triggers under `functions/`, while shared business logic for agents, tools, and middleware lives under dedicated packages in the repo root.
+
+## Key directories
+- `function_app.py`: Azure Functions entry point that wires triggers to the shared FastAPI-style app object.
+- `functions/`: Individual function triggers (HTTP, queue, timer, Cosmos DB).  Tests mock these functions directly.
+- `agents/`: Agent implementations built on LangChain / LangGraph.
+- `middleware/`: Reusable middleware and routing helpers for orchestrating the agent graph.
+- `infra/`: Bicep templates and deployment assets.
+- `tests/`: Pytest suite covering the Azure Functions and agent behaviors.  Test data fixtures are under `tests/data/`.
+
+## Environment setup
+1. Install Python 3.12.
+2. Prefer [`uv`](https://github.com/astral-sh/uv) for dependency management:
+   ```bash
+   uv sync
+   ```
+   Alternatively you can fall back to `pip install -r requirements.txt`.
+3. Activate the virtual environment that `uv` creates (`.venv/`) or ensure your interpreter points at the synced environment.
+4. Populate the following environment variables when running live against Azure services:
+   - `AZURE_OPENAI_ENDPOINT`
+   - `AZURE_OPENAI_API_KEY`
+   - `AzureWebJobsStorage`
+   - `CosmosDbConnection`, `CosmosDatabase`, `CosmosContainer`
+   - `SqlConnectionString` (if SQL bindings are used)
+   Local tests typically mock these values, so they are not required for `pytest`.
+
+## Common commands
+- Run the full test suite:
+  ```bash
+  uv run pytest
+  ```
+- Run a single test module:
+  ```bash
+  uv run pytest tests/test_http_conversation.py
+  ```
+- Lint and type-check the project:
+  ```bash
+  uv run ruff check .
+  uv run mypy .
+  ```
+- Start the local Azure Functions host after installing requirements:
+  ```bash
+  func start
+  ```
+
+## Coding guidelines
+- Follow standard Python typing practices; the project targets Python 3.12 with `from __future__ import annotations` where useful.
+- Keep Azure Function handlers stateless.  Use helpers in `agents/` and `middleware/` for shared state.
+- Prefer small, pure functions for agent tools and include docstrings describing tool contracts.
+- Update or add pytest coverage when modifying behavior.  Tests should not depend on real Azure resources; use fixtures or monkeypatching.
+
+## Pull request & CI expectations
+- Ensure `uv run pytest`, `uv run ruff check .`, and `uv run mypy .` complete without errors before submitting a PR.
+- Follow conventional commit-style messages when possible (e.g., `feat:`, `fix:`, `chore:`) to keep history readable.
+- Describe any required environment variables or infra changes in the PR body if they are relevant to reviewers.

--- a/agents/testing_agent/__init__.py
+++ b/agents/testing_agent/__init__.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+"""Testing agent focused on exercising Azure AI Search tools."""
+
+from pathlib import Path
+
+from ..vanilla_agent import VanillaAgent
+
+
+class TestingAgent(VanillaAgent):
+    """Agent wired with Azure AI Search retrieval tools."""
+
+    def __init__(self) -> None:
+        config_dir = Path(__file__).parent
+        super().__init__(
+            config_path=config_dir / "config.json",
+            instructions_path=config_dir / "instructions.md",
+        )
+
+
+# Prevent pytest from mistaking the agent class for a test container.
+TestingAgent.__test__ = False

--- a/agents/testing_agent/config.json
+++ b/agents/testing_agent/config.json
@@ -1,0 +1,8 @@
+{
+  "displayName": "Testing Agent",
+  "id": "testing_agent",
+  "description": "Agent designed to exercise Azure AI Search integrations and surface test knowledge.",
+  "handover": [],
+  "tools": ["azure_ai_search"],
+  "model": "gpt-4.1"
+}

--- a/agents/testing_agent/instructions.md
+++ b/agents/testing_agent/instructions.md
@@ -1,0 +1,12 @@
+You are Testing Agent, a specialized assistant that validates Azure AI Search integrations.
+
+Goals:
+- Interpret user requests about documentation, test data, or diagnostics.
+- Use the `azure_ai_search` tool to retrieve supporting context from the configured Azure AI Search index.
+- Summarize the retrieved information and note any gaps in coverage.
+- Clearly call out when no relevant entries are returned.
+
+Operational notes:
+- Prefer concise, bullet-style summaries of search results ordered by relevance.
+- Include metadata fields such as `source` or `category` when available in the results.
+- Do not fabricate data; if search returns nothing, state that explicitly.

--- a/middleware/azure_search_tools.py
+++ b/middleware/azure_search_tools.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+"""Tools for retrieving data from Azure AI Search."""
+
+import os
+from dataclasses import dataclass
+from typing import Any, Iterable, Optional
+
+try:  # pragma: no cover - optional dependency surface
+    from langchain.tools import BaseTool
+except Exception:  # pragma: no cover
+    class BaseTool:  # type: ignore[too-many-ancestors]
+        """Fallback BaseTool used when LangChain is unavailable."""
+
+        name: str = ""
+        description: str = ""
+
+        def __init__(self, *args, **kwargs) -> None:  # noqa: D401
+            pass
+
+        def run(self, *args, **kwargs):  # pragma: no cover - passthrough wrapper
+            return self._run(*args, **kwargs)
+
+        # pylint: disable=unused-argument
+        def _run(self, *args, **kwargs):  # pragma: no cover - abstract placeholder
+            raise NotImplementedError
+
+        async def _arun(self, *args, **kwargs):  # pragma: no cover - async unsupported
+            raise NotImplementedError
+
+try:  # pragma: no cover - pydantic might not be installed in minimal envs
+    from pydantic import BaseModel, Field, PrivateAttr
+except Exception:  # pragma: no cover
+    class BaseModel:  # type: ignore[too-many-ancestors]
+        def __init__(self, **data: Any) -> None:
+            for key, value in data.items():
+                setattr(self, key, value)
+
+    def Field(default: Any, description: str = "") -> Any:
+        return default
+
+    def PrivateAttr(default: Any = None) -> Any:
+        return default
+
+_MISSING = object()
+_RETRIEVER_CLS: Any = _MISSING
+
+
+def _get_retriever_cls() -> Any | None:
+    """Dynamically import the Azure retriever only when required."""
+
+    global _RETRIEVER_CLS  # noqa: PLW0603 - cache for repeated calls
+    if _RETRIEVER_CLS is _MISSING:
+        try:  # pragma: no cover - optional dependency surface
+            from langchain_community.retrievers import AzureCognitiveSearchRetriever
+        except Exception:
+            _RETRIEVER_CLS = None
+        else:
+            _RETRIEVER_CLS = AzureCognitiveSearchRetriever
+    return None if _RETRIEVER_CLS is None else _RETRIEVER_CLS
+
+from langchain_core.tools import tool
+
+
+TOOL_DESCRIPTION = "Search the Azure AI Search index for relevant machine information."
+
+
+class AzureAISearchToolInput(BaseModel):
+    """Input schema for :class:`AzureAISearchTool`."""
+
+    query: str = Field(..., description="Natural language search query.")
+    top_k: Optional[int] = Field(
+        default=None,
+        description="Optional limit for the number of results to return.",
+    )
+
+
+@dataclass
+class _RenderableDocument:
+    """Lightweight container for formatted document output."""
+
+    content: str
+    metadata: dict[str, Any]
+
+    def format(self) -> str:
+        """Format a document for presentation to the model."""
+
+        meta_lines = [f"{key}: {value}" for key, value in self.metadata.items()]
+        meta_block = f"\nMetadata: {', '.join(meta_lines)}" if meta_lines else ""
+        return f"{self.content}{meta_block}"
+
+
+class AzureAISearchTool(BaseTool):
+    """LangChain tool that queries Azure AI Search and formats results."""
+
+    name: str = "azure_ai_search"
+    description: str = TOOL_DESCRIPTION
+    args_schema: type[BaseModel] = AzureAISearchToolInput
+
+    endpoint: Optional[str] = None
+    api_key: Optional[str] = None
+    index_name: Optional[str] = None
+    content_key: str = "content"
+    top_k: int = 5
+    vector_field: Optional[str] = None
+    _retriever: Any = PrivateAttr(default=None)
+
+    def __init__(
+        self,
+        *,
+        endpoint: Optional[str] = None,
+        api_key: Optional[str] = None,
+        index_name: Optional[str] = None,
+        content_key: Optional[str] = None,
+        top_k: Optional[int] = None,
+        vector_field: Optional[str] = None,
+        retriever: Any | None = None,
+    ) -> None:
+        super().__init__()
+        self.endpoint = endpoint or os.environ.get("AZURE_SEARCH_ENDPOINT")
+        self.api_key = api_key or os.environ.get("AZURE_SEARCH_API_KEY")
+        self.index_name = index_name or os.environ.get("AZURE_SEARCH_INDEX_NAME")
+        self.content_key = (
+            content_key
+            or os.environ.get("AZURE_SEARCH_CONTENT_KEY")
+            or "content"
+        )
+        raw_top_k = top_k or os.environ.get("AZURE_SEARCH_TOP_K")
+        try:
+            self.top_k = int(raw_top_k) if raw_top_k is not None else 5
+        except (TypeError, ValueError):  # pragma: no cover - defensive parsing
+            self.top_k = 5
+        self.vector_field = vector_field or os.environ.get("AZURE_SEARCH_VECTOR_FIELD")
+        if retriever is not None:
+            self._retriever = retriever
+        elif all([self.endpoint, self.api_key, self.index_name]):
+            self._retriever = self._build_retriever()
+        else:
+            self._retriever = None
+
+    # ------------------------------------------------------------------
+    def _build_retriever(self) -> Any | None:
+        """Instantiate a LangChain retriever if dependencies are available."""
+
+        retriever_cls = _get_retriever_cls()
+        if retriever_cls is None:
+            return None
+        if not all([self.endpoint, self.api_key, self.index_name]):
+            return None
+        try:
+            retriever = retriever_cls(
+                endpoint=self.endpoint,
+                api_key=self.api_key,
+                index_name=self.index_name,
+                content_key=self.content_key,
+                top_k=self.top_k,
+            )
+            if self.vector_field and hasattr(retriever, "vector_field"):
+                setattr(retriever, "vector_field", self.vector_field)
+            return retriever
+        except Exception:  # pragma: no cover - avoid crashing on SDK errors
+            return None
+
+    # ------------------------------------------------------------------
+    def run(self, *args: Any, **kwargs: Any) -> str:  # noqa: D401 - wrapper
+        """Support multiple invocation styles for compatibility with LangChain."""
+
+        query: Optional[str] = None
+        top_k: Optional[int] = None
+        if args:
+            first_arg = args[0]
+            if isinstance(first_arg, str):
+                query = first_arg
+            elif isinstance(first_arg, dict):
+                query = first_arg.get("query")
+                top_k = first_arg.get("top_k")
+            else:
+                query = getattr(first_arg, "query", None)
+                top_k = getattr(first_arg, "top_k", None)
+        if "tool_input" in kwargs:
+            tool_input = kwargs["tool_input"]
+            if isinstance(tool_input, dict):
+                query = tool_input.get("query") or query
+                top_k = tool_input.get("top_k") if top_k is None else top_k
+            else:
+                query = getattr(tool_input, "query", query)
+                top_k = getattr(tool_input, "top_k", top_k)
+        query = kwargs.get("query", query)
+        top_k = kwargs.get("top_k", top_k)
+        if query is None:
+            raise TypeError("Missing required argument 'query'")
+        return self._run(query=query, top_k=top_k)
+
+    # pylint: disable=unused-argument
+    def _run(self, query: str, top_k: Optional[int] = None) -> str:  # type: ignore[override]
+        retriever = self._ensure_retriever()
+        self._configure_top_k(retriever, top_k)
+        documents = retriever.get_relevant_documents(query)
+        formatted = self._format_documents(documents)
+        if not formatted:
+            return "No relevant information found in Azure AI Search."
+        return "\n\n".join(doc.format() for doc in formatted)
+
+    async def _arun(self, query: str, top_k: Optional[int] = None) -> str:  # type: ignore[override]
+        raise NotImplementedError("AzureAISearchTool does not support async execution")
+
+    # ------------------------------------------------------------------
+    def _ensure_retriever(self) -> Any:
+        if self._retriever is None:
+            missing = [
+                name
+                for name, value in (
+                    ("AZURE_SEARCH_ENDPOINT", self.endpoint),
+                    ("AZURE_SEARCH_API_KEY", self.api_key),
+                    ("AZURE_SEARCH_INDEX_NAME", self.index_name),
+                )
+                if not value
+            ]
+            missing_env = ", ".join(missing)
+            raise RuntimeError(
+                "Azure AI Search retriever is not configured."
+                + (f" Missing settings: {missing_env}" if missing_env else "")
+            )
+        return self._retriever
+
+    @staticmethod
+    def _configure_top_k(retriever: Any, top_k: Optional[int]) -> None:
+        if top_k is None:
+            return
+        for attr in ("top_k", "k"):
+            if hasattr(retriever, attr):
+                try:
+                    setattr(retriever, attr, top_k)
+                    return
+                except Exception:  # pragma: no cover - best effort
+                    continue
+
+    @staticmethod
+    def _format_documents(documents: Iterable[Any]) -> list[_RenderableDocument]:
+        formatted: list[_RenderableDocument] = []
+        for doc in documents:
+            if doc is None:  # pragma: no cover - guard for defensive callers
+                continue
+            content = getattr(doc, "page_content", None) or str(doc)
+            metadata = getattr(doc, "metadata", None)
+            if not isinstance(metadata, dict):
+                metadata = {}
+            formatted.append(_RenderableDocument(content=content, metadata=metadata))
+        return formatted
+
+
+@tool("azure_ai_search", description=TOOL_DESCRIPTION)
+def azure_ai_search(query: str) -> str:
+    """Tool entry-point that instantiates :class:`AzureAISearchTool`."""
+
+    return AzureAISearchTool().run(query=query)
+

--- a/tests/test_azure_search_tools.py
+++ b/tests/test_azure_search_tools.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from middleware import azure_search_tools
+
+
+class FakeRetriever:
+    def __init__(self, documents):
+        self._documents = list(documents)
+        self.received_queries: list[str] = []
+        self.top_k = len(self._documents)
+
+    def get_relevant_documents(self, query):
+        self.received_queries.append(query)
+        return list(self._documents)
+
+
+class FakeDocument(types.SimpleNamespace):
+    pass
+
+
+def test_tool_formats_results(monkeypatch):
+    docs = [
+        FakeDocument(page_content="Pump calibration guide", metadata={"source": "kb1"}),
+        FakeDocument(page_content="Replace filter", metadata={"source": "kb2", "score": 0.42}),
+    ]
+    tool = azure_search_tools.AzureAISearchTool(retriever=FakeRetriever(docs))
+
+    output = tool.run(query="calibration steps")
+
+    assert "Pump calibration guide" in output
+    assert "source: kb1" in output
+    assert "Replace filter" in output
+    assert "score: 0.42" in output
+
+
+def test_tool_missing_configuration(monkeypatch):
+    monkeypatch.delenv("AZURE_SEARCH_ENDPOINT", raising=False)
+    monkeypatch.delenv("AZURE_SEARCH_API_KEY", raising=False)
+    monkeypatch.delenv("AZURE_SEARCH_INDEX_NAME", raising=False)
+    tool = azure_search_tools.AzureAISearchTool(retriever=None)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        tool.run(query="status")
+
+    assert "not configured" in str(exc_info.value)
+
+
+def test_tool_respects_top_k(monkeypatch):
+    docs = [
+        FakeDocument(page_content="Result 1", metadata={}),
+        FakeDocument(page_content="Result 2", metadata={}),
+        FakeDocument(page_content="Result 3", metadata={}),
+    ]
+    retriever = FakeRetriever(docs)
+    tool = azure_search_tools.AzureAISearchTool(retriever=retriever)
+
+    tool.run({"query": "anything", "top_k": 1})
+
+    assert retriever.top_k == 1
+    assert retriever.received_queries == ["anything"]

--- a/tests/test_testing_agent.py
+++ b/tests/test_testing_agent.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from langchain_core.messages import AIMessage
+
+import agents.vanilla_agent as vanilla_agent
+from agents.testing_agent import TestingAgent
+from middleware import azure_search_tools
+
+
+class FakeListChatModel:
+    """Simple fake chat model returning preset responses."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+
+    def bind_tools(self, tools):
+        return self
+
+    def invoke(self, messages):
+        return self._responses.pop(0)
+
+
+class StubTool:
+    """Tool stub that records invocations and returns canned payloads."""
+
+    name = "azure_ai_search"
+
+    def __init__(self, payload: str) -> None:
+        self.payload = payload
+        self.calls: list[dict[str, str]] = []
+
+    def run(self, *args, **kwargs):  # type: ignore[unused-argument]
+        if args and isinstance(args[0], dict):
+            self.calls.append(args[0])
+        elif "query" in kwargs:
+            self.calls.append({"query": kwargs["query"]})
+        return self.payload
+
+
+def _build_tool_calling_model(payload: str) -> FakeListChatModel:
+    tool_call_message = AIMessage(
+        content="",
+        additional_kwargs={
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "function": {
+                        "name": "azure_ai_search",
+                        "arguments": json.dumps({"query": "test query"}),
+                    },
+                }
+            ]
+        },
+    )
+    final_message = AIMessage(content="Search complete")
+    return FakeListChatModel([tool_call_message, final_message])
+
+
+def test_testing_agent_invokes_search_tool(monkeypatch):
+    payload = "Result payload"
+    fake_tool = StubTool(payload)
+    monkeypatch.setattr(azure_search_tools, "AzureAISearchTool", lambda **_: fake_tool)
+    fake_model = _build_tool_calling_model(payload)
+    monkeypatch.setattr(vanilla_agent, "AzureChatOpenAI", lambda **_: fake_model)
+    vanilla_agent.VanillaAgent.MEMORY = []
+
+    agent = TestingAgent()
+
+    result = agent.invoke({"input": "Find calibration steps"})
+
+    tool_messages = [
+        message
+        for message in result["messages"]
+        if message.__class__.__name__ == "ToolMessage"
+    ]
+    assert tool_messages, "The tool message should be present in the conversation."
+    assert payload in tool_messages[0].content
+    assert result["messages"][-1].content == "Search complete"
+    assert fake_tool.calls and fake_tool.calls[0]["query"] == "test query"
+
+
+def test_testing_agent_reports_no_results(monkeypatch):
+    fake_tool = StubTool("No relevant information found in Azure AI Search.")
+    monkeypatch.setattr(azure_search_tools, "AzureAISearchTool", lambda **_: fake_tool)
+    fake_model = _build_tool_calling_model("unused")
+    monkeypatch.setattr(vanilla_agent, "AzureChatOpenAI", lambda **_: fake_model)
+    vanilla_agent.VanillaAgent.MEMORY = []
+
+    agent = TestingAgent()
+    result = agent.invoke({"input": "Any query"})
+
+    tool_messages = [
+        message
+        for message in result["messages"]
+        if message.__class__.__name__ == "ToolMessage"
+    ]
+    assert tool_messages
+    assert "No relevant information" in tool_messages[-1].content


### PR DESCRIPTION
## Summary
- add an Azure AI Search tool module that formats retriever results and exposes a LangChain tool entry point
- register a new testing agent configuration that exercises the Azure AI Search tool with dedicated instructions
- cover the integration with unit tests for the tool and testing agent interactions

## Testing
- MANUALS_MD_CONNECTION_STRING="" AzureWebJobsStorage="" pytest

------
https://chatgpt.com/codex/tasks/task_e_68da4827ada4832cab311fab2b0099be