### PR TITLE
fix: mint new conversation ids on reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,20 +85,28 @@ import gradio as gr
 
 ### `POST /api/conversationRun`
 
-Invoke the conversational model via an HTTP POST. The body must include an
-`input` field containing the user's message. The function maintains the shared
-conversation history in memory.
+Invoke the conversational model via an HTTP POST. The body must include:
+
+- `conversation_id`: Stable identifier for the transcript (per user/session).
+- `input`: The latest user utterance. This value may be text or a multimodal
+  payload compatible with LangChain's `HumanMessage`.
+
+Each invocation loads the full transcript for the provided `conversation_id` from
+Cosmos DB, appends the new message, executes the agent graph, and persists the
+updated transcript back to Cosmos. Reusing the same identifier maintains
+conversation continuity, while using a different one isolates history.
 
 ```http
 POST /api/conversationRun
 Content-Type: application/json
 
 {
+  "conversation_id": "demo-42",
   "input": "What is the status of machine 42?"
 }
 ```
 
-Example response:
+Example response (latest assistant reply):
 
 ```json
 {
@@ -108,8 +116,10 @@ Example response:
 
 ### `POST /api/conversationReset`
 
-Reset the shared conversation state. This is useful when starting a brand-new
-session from the Gradio UI or another client.
+Request a fresh `conversation_id`. Optionally include the previous identifier
+if you want it echoed back in the response. The prior transcript is left in
+Cosmos DB so that historical conversations remain available for auditing or
+future retrieval.
 
 ```http
 POST /api/conversationReset
@@ -122,7 +132,9 @@ Example response:
 
 ```json
 {
-  "status": "reset"
+  "status": "reset",
+  "conversation_id": "c783b8ac-5e53-4af2-9bcb-73cf43c8ce19",
+  "previous_conversation_id": null
 }
 ```
 
@@ -135,6 +147,10 @@ Configure local settings in `local.settings.json` (no secrets committed). Requir
 - `AzureWebJobsStorage` (for local emulator or real storage)
 - `CosmosDbConnection`, `CosmosDatabase`, `CosmosContainer` (for Cosmos trigger)
 - `SqlConnectionString` (if using SQL access/bindings)
+
+The Cosmos container now stores per-conversation transcripts keyed by the
+`conversation_id` you pass to the HTTP API. Provision it with an `/id` partition
+key (the default in `infra/main.bicep`) to align with the persistence model.
 
 ### Deployment
 

--- a/agents/vanilla_agent.py
+++ b/agents/vanilla_agent.py
@@ -23,7 +23,7 @@ from langgraph.graph import StateGraph, START, END, MessagesState
 from langgraph.prebuilt import ToolNode, InjectedState, tools_condition
 from langgraph.types import Command
 from langchain_core.tools import tool, InjectedToolCallId
-from typing import Annotated
+from typing import Annotated, Sequence
 from langchain_core.messages.utils import convert_to_openai_messages
 
 
@@ -115,15 +115,26 @@ class VanillaAgent:
         return graph.compile()
 
     # invocation ---------------------------------------------------------
-    def invoke(self, inputs: dict[str, Any] | str) -> Any:
-        if isinstance(inputs, dict):
-            input_text = inputs.get("input", "")
+    def invoke(
+        self,
+        inputs: dict[str, Any] | str,
+        *,
+        history: Sequence[BaseMessage] | None = None,
+    ) -> Any:
+        if isinstance(inputs, dict) and "messages" in inputs:
+            raw_messages = inputs["messages"]
+            if isinstance(raw_messages, Sequence) and not isinstance(raw_messages, (str, bytes)):
+                messages = list(raw_messages)
+            else:
+                messages = [raw_messages]
         else:
-            input_text = inputs
-        messages = [*VanillaAgent.MEMORY, HumanMessage(content=input_text)]
-        result = self.graph.invoke({"messages": messages})
-        VanillaAgent.MEMORY = result.get("messages", messages)
-        return result
+            messages = list(history or [])
+            if isinstance(inputs, dict):
+                if "input" in inputs and inputs["input"] is not None:
+                    messages.append(HumanMessage(content=inputs["input"]))
+            else:
+                messages.append(HumanMessage(content=inputs))
+        return self.graph.invoke({"messages": messages})
 
     # helpers ------------------------------------------------------------
     @staticmethod

--- a/functions/http_conversation.py
+++ b/functions/http_conversation.py
@@ -1,14 +1,23 @@
 import json
 import logging
+import uuid
 
 import azure.functions as func
 from function_app import app
 
-from langchain_core.messages import HumanMessage
-from agents import build_graph, VanillaAgent
+from langchain_core.messages import AIMessage, HumanMessage
+from agents import build_graph
+from middleware.conversation_store import ConversationStore
 
 
 _graph = None
+_store: ConversationStore | None = None
+
+def _get_store() -> ConversationStore:
+    global _store
+    if _store is None:
+        _store = ConversationStore()
+    return _store
 
 
 @app.route(route="conversationRun", auth_level=func.AuthLevel.FUNCTION)
@@ -25,6 +34,11 @@ def conversation_run(req: func.HttpRequest) -> func.HttpResponse:
     if not isinstance(body, dict):
         return func.HttpResponse(body="Invalid JSON when checking body type", status_code=400)
 
+    conversation_id = body.get("conversation_id")
+    if not isinstance(conversation_id, str) or not conversation_id.strip():
+        return func.HttpResponse(body="conversation_id is required", status_code=400)
+    conversation_id = conversation_id.strip()
+
     input_data = body.get("input")
     logging.debug(f"Input data: {input_data}")
     if input_data is None:
@@ -34,10 +48,18 @@ def conversation_run(req: func.HttpRequest) -> func.HttpResponse:
     if _graph is None:
         _graph = build_graph()
 
-    messages = [*VanillaAgent.MEMORY, HumanMessage(content=input_data)]
+    store = _get_store()
+    history = list(store.load_messages(conversation_id))
+    messages = [*history, HumanMessage(content=input_data)]
     result = _graph.invoke({"messages": messages})
-    VanillaAgent.MEMORY = result.get("messages", messages)
-    output_msg = VanillaAgent.MEMORY[-1].content if VanillaAgent.MEMORY else ""
+    result_messages = list(result.get("messages", messages))
+    store.save_messages(conversation_id, result_messages)
+
+    output_msg: object = ""
+    for message in reversed(result_messages):
+        if isinstance(message, AIMessage):
+            output_msg = message.content
+            break
 
     return func.HttpResponse(
         json.dumps({"output": output_msg}),
@@ -56,13 +78,33 @@ def conversation_reset(req: func.HttpRequest) -> func.HttpResponse:
 
     logging.info("HTTP conversationReset invoked")
 
-    VanillaAgent.MEMORY = []
+    try:
+        body = req.get_json()
+    except ValueError:
+        return func.HttpResponse(body="Invalid JSON when parsing request body", status_code=400)
+
+    if not isinstance(body, dict):
+        return func.HttpResponse(body="Invalid JSON when checking body type", status_code=400)
+
+    conversation_id = body.get("conversation_id")
+    if conversation_id is not None:
+        if not isinstance(conversation_id, str) or not conversation_id.strip():
+            return func.HttpResponse(body="conversation_id is required", status_code=400)
+        conversation_id = conversation_id.strip()
+
+    new_conversation_id = str(uuid.uuid4())
 
     global _graph
     _graph = None
 
     return func.HttpResponse(
-        json.dumps({"status": "reset"}),
+        json.dumps(
+            {
+                "status": "reset",
+                "conversation_id": new_conversation_id,
+                "previous_conversation_id": conversation_id,
+            }
+        ),
         status_code=200,
         mimetype="application/json",
     )

--- a/infra/README.md
+++ b/infra/README.md
@@ -11,7 +11,8 @@ Parameters (main.bicep)
 - `location`: Azure region (e.g., `westeurope`)
 - `namePrefix`: Prefix for resource names (lowercase, letters and digits)
 - `cosmosDbName`: Cosmos DB database name
-- `cosmosContainerName`: Cosmos DB container name
+- `cosmosContainerName`: Cosmos DB container name (stores per-conversation
+  transcripts partitioned by `/id`)
 - `sqlAdminLogin` / `sqlAdminPassword`: SQL admin credentials
 - `manualsMdConnectionString`: Connection string for manuals markdown storage (blob container)
 - `azureOpenAiEndpoint`: Azure OpenAI endpoint URL

--- a/middleware/conversation_store.py
+++ b/middleware/conversation_store.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+"""Cosmos-backed persistence for conversation transcripts."""
+
+import os
+from typing import Iterable
+
+from azure.cosmos import CosmosClient, exceptions
+from langchain_core.messages import BaseMessage, messages_from_dict, messages_to_dict
+
+
+class ConversationStore:
+    """Persist and retrieve serialized LangChain message transcripts."""
+
+    def __init__(
+        self,
+        *,
+        connection_string: str | None = None,
+        database_name: str | None = None,
+        container_name: str | None = None,
+        container=None,
+    ) -> None:
+        self._connection_string = connection_string or os.getenv("CosmosDbConnection")
+        self._database_name = database_name or os.getenv("CosmosDatabase")
+        self._container_name = container_name or os.getenv("CosmosContainer")
+        self._container = container
+        self._client: CosmosClient | None = None
+
+    def _get_container(self):
+        if self._container is not None:
+            return self._container
+        if not self._connection_string:
+            raise RuntimeError("CosmosDbConnection must be configured for ConversationStore")
+        if not self._database_name:
+            raise RuntimeError("CosmosDatabase must be configured for ConversationStore")
+        if not self._container_name:
+            raise RuntimeError("CosmosContainer must be configured for ConversationStore")
+        if self._client is None:
+            self._client = CosmosClient.from_connection_string(self._connection_string)
+        database = self._client.get_database_client(self._database_name)
+        self._container = database.get_container_client(self._container_name)
+        return self._container
+
+    def load_messages(self, conversation_id: str) -> list[BaseMessage]:
+        """Return the stored transcript for ``conversation_id`` if present."""
+
+        if not conversation_id:
+            return []
+        container = self._get_container()
+        try:
+            record = container.read_item(item=conversation_id, partition_key=conversation_id)
+        except exceptions.CosmosResourceNotFoundError:
+            return []
+        messages_data = record.get("messages", [])
+        if not messages_data:
+            return []
+        return list(messages_from_dict(messages_data))
+
+    def save_messages(self, conversation_id: str, messages: Iterable[BaseMessage]) -> None:
+        """Persist ``messages`` under ``conversation_id``."""
+
+        container = self._get_container()
+        serialized = messages_to_dict(list(messages))
+        container.upsert_item({"id": conversation_id, "messages": serialized})
+
+    def delete(self, conversation_id: str) -> None:
+        """Remove the stored transcript, ignoring missing records."""
+
+        if not conversation_id:
+            return
+        container = self._get_container()
+        try:
+            container.delete_item(item=conversation_id, partition_key=conversation_id)
+        except exceptions.CosmosResourceNotFoundError:
+            return

--- a/tests/test_http_conversation.py
+++ b/tests/test_http_conversation.py
@@ -2,20 +2,39 @@
 from __future__ import annotations
 
 import json
+import uuid
+from types import SimpleNamespace
 
 import azure.functions as func
 from langchain_core.messages import AIMessage, HumanMessage
 
 from functions import http_conversation
-from agents import VanillaAgent
 
 
 class DummyGraph:
     def __init__(self, result):
         self._result = result
+        self.invocations = []
 
     def invoke(self, state):  # pragma: no cover - simple passthrough
+        self.invocations.append(state)
         return self._result
+
+
+class DummyStore:
+    def __init__(self):
+        self.records: dict[str, list] = {}
+        self.deleted: list[str] = []
+
+    def load_messages(self, conversation_id: str):
+        return self.records.get(conversation_id, [])
+
+    def save_messages(self, conversation_id: str, messages):
+        self.records[conversation_id] = list(messages)
+
+    def delete(self, conversation_id: str):
+        self.records.pop(conversation_id, None)
+        self.deleted.append(conversation_id)
 
 
 def _make_request(body: dict) -> func.HttpRequest:
@@ -30,41 +49,142 @@ def _make_request(body: dict) -> func.HttpRequest:
 
 
 def test_conversation_run_plain_text(monkeypatch):
-    result = {
-        "messages": [HumanMessage(content="hello"), AIMessage(content="text response")]
-    }
-    monkeypatch.setattr(http_conversation, "_graph", DummyGraph(result))
-    VanillaAgent.MEMORY = []
-    req = _make_request({"input": "hello"})
+    store = DummyStore()
+    store.records["conv-1"] = [HumanMessage(content="previous")]
+    result_messages = [
+        HumanMessage(content="previous"),
+        HumanMessage(content="hello"),
+        AIMessage(content="text response"),
+    ]
+    graph = DummyGraph({"messages": result_messages})
+    monkeypatch.setattr(http_conversation, "_graph", graph)
+    monkeypatch.setattr(http_conversation, "_store", store)
+
+    req = _make_request({"conversation_id": "conv-1", "input": "hello"})
     resp = http_conversation.conversation_run(req)
+
     assert resp.status_code == 200
     assert json.loads(resp.get_body()) == {"output": "text response"}
+    assert store.records["conv-1"] == result_messages
+    assert len(graph.invocations) == 1
+    invoked_messages = graph.invocations[0]["messages"]
+    assert invoked_messages[0].content == "previous"
+    assert invoked_messages[-1].content == "hello"
 
 
 def test_conversation_run_multimodal(monkeypatch):
-    result = {
-        "messages": [
-            HumanMessage(
-                content=[
-                    {"type": "text", "text": "describe"},
-                    {
-                        "type": "image_url",
-                        "image_url": {"url": "https://example.com/cat.png"},
-                    },
-                ]
-            ),
-            AIMessage(content="image response"),
-        ]
-    }
-    monkeypatch.setattr(http_conversation, "_graph", DummyGraph(result))
-    VanillaAgent.MEMORY = []
+    store = DummyStore()
+    result_messages = [
+        HumanMessage(
+            content=[
+                {"type": "text", "text": "describe"},
+                {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+            ]
+        ),
+        AIMessage(content="image response"),
+    ]
+    graph = DummyGraph({"messages": result_messages})
+    monkeypatch.setattr(http_conversation, "_graph", graph)
+    monkeypatch.setattr(http_conversation, "_store", store)
+
     body = {
+        "conversation_id": "conv-2",
         "input": [
             {"type": "text", "text": "describe"},
             {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
-        ]
+        ],
     }
     req = _make_request(body)
     resp = http_conversation.conversation_run(req)
+
     assert resp.status_code == 200
     assert json.loads(resp.get_body()) == {"output": "image response"}
+    assert store.records["conv-2"] == result_messages
+
+
+def test_conversation_run_requires_conversation_id(monkeypatch):
+    store = DummyStore()
+    monkeypatch.setattr(http_conversation, "_store", store)
+    monkeypatch.setattr(http_conversation, "_graph", DummyGraph({"messages": []}))
+
+    req = _make_request({"input": "hello"})
+    resp = http_conversation.conversation_run(req)
+
+    assert resp.status_code == 400
+    assert b"conversation_id is required" in resp.get_body()
+
+
+def test_conversation_run_isolated_histories(monkeypatch):
+    store = DummyStore()
+    store.records["alpha"] = [HumanMessage(content="a previous question")]
+    store.records["beta"] = [HumanMessage(content="b previous question")]
+
+    alpha_result = [
+        HumanMessage(content="a previous question"),
+        HumanMessage(content="alpha new"),
+        AIMessage(content="alpha answer"),
+    ]
+    beta_result = [
+        HumanMessage(content="b previous question"),
+        HumanMessage(content="beta new"),
+        AIMessage(content="beta answer"),
+    ]
+
+    class SwitchingGraph:
+        def __init__(self):
+            self.invocations = []
+
+        def invoke(self, state):
+            self.invocations.append(state)
+            latest = state["messages"][-1].content
+            return {"messages": alpha_result if str(latest).startswith("alpha") else beta_result}
+
+    graph = SwitchingGraph()
+    monkeypatch.setattr(http_conversation, "_graph", graph)
+    monkeypatch.setattr(http_conversation, "_store", store)
+
+    req_alpha = _make_request({"conversation_id": "alpha", "input": "alpha new"})
+    req_beta = _make_request({"conversation_id": "beta", "input": "beta new"})
+
+    resp_alpha = http_conversation.conversation_run(req_alpha)
+    resp_beta = http_conversation.conversation_run(req_beta)
+
+    assert resp_alpha.status_code == 200
+    assert resp_beta.status_code == 200
+
+    assert graph.invocations[0]["messages"][0].content == "a previous question"
+    assert graph.invocations[1]["messages"][0].content == "b previous question"
+
+    assert store.records["alpha"] == alpha_result
+    assert store.records["beta"] == beta_result
+
+
+def test_conversation_reset_returns_new_identifier(monkeypatch):
+    store = DummyStore()
+    store.records["conv-3"] = [HumanMessage(content="old question")]
+    monkeypatch.setattr(http_conversation, "_store", store)
+    monkeypatch.setattr(http_conversation, "_graph", DummyGraph({"messages": []}))
+    monkeypatch.setattr(
+        http_conversation,
+        "uuid",
+        SimpleNamespace(uuid4=lambda: uuid.UUID("00000000-0000-0000-0000-000000000123")),
+    )
+
+    req = func.HttpRequest(
+        method="POST",
+        url="/api/conversationReset",
+        headers={"Content-Type": "application/json"},
+        params={},
+        route_params={},
+        body=json.dumps({"conversation_id": "conv-3"}).encode(),
+    )
+    resp = http_conversation.conversation_reset(req)
+
+    assert resp.status_code == 200
+    assert store.records["conv-3"] == [HumanMessage(content="old question")]
+    assert store.deleted == []
+    assert json.loads(resp.get_body()) == {
+        "status": "reset",
+        "conversation_id": "00000000-0000-0000-0000-000000000123",
+        "previous_conversation_id": "conv-3",
+    }


### PR DESCRIPTION
## Summary
- update the conversation reset endpoint to issue a fresh conversation identifier instead of deleting the previous transcript
- document the new reset workflow and capture it with unit tests that assert the new id is returned and history remains intact

## Testing
- pytest tests/test_http_conversation.py

------
https://chatgpt.com/codex/tasks/task_e_68dd56441fc8832c8dc2f8b1c4d44021